### PR TITLE
Feat/create transactions

### DIFF
--- a/lib/banking_api/bank.ex
+++ b/lib/banking_api/bank.ex
@@ -101,4 +101,146 @@ defmodule BankingApi.Bank do
   def change_account(%Account{} = account, attrs \\ %{}) do
     Account.changeset(account, attrs)
   end
+
+  alias BankingApi.Bank.Transaction
+
+  @doc """
+  Returns the list of transactions.
+
+  ## Examples
+
+      iex> list_transactions()
+      [%Transaction{}, ...]
+
+  """
+  def list_transactions do
+    Repo.all(Transaction)
+  end
+
+  @doc """
+  Gets a single transaction.
+
+  Raises `Ecto.NoResultsError` if the Transaction does not exist.
+
+  ## Examples
+
+      iex> get_transaction!(123)
+      %Transaction{}
+
+      iex> get_transaction!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_transaction!(id), do: Repo.get!(Transaction, id)
+
+  @doc """
+  Creates a transaction.
+
+  ## Examples
+
+      iex> create_transaction(%{field: value})
+      {:ok, %Transaction{}}
+
+      iex> create_transaction(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_transaction(attrs \\ %{}) do
+    changeset =
+      %Transaction{}
+      |> Transaction.changeset(attrs)
+      |> Repo.insert()
+
+    case changeset do
+      {:ok, transaction} ->
+        {:ok, Repo.preload(transaction, postings: :account)}
+
+      changeset ->
+        changeset
+    end
+  end
+
+  @doc """
+  Updates a transaction.
+
+  ## Examples
+
+      iex> update_transaction(transaction, %{field: new_value})
+      {:ok, %Transaction{}}
+
+      iex> update_transaction(transaction, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_transaction(%Transaction{} = transaction, attrs) do
+    transaction
+    |> Transaction.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a transaction.
+
+  ## Examples
+
+      iex> delete_transaction(transaction)
+      {:ok, %Transaction{}}
+
+      iex> delete_transaction(transaction)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_transaction(%Transaction{} = transaction) do
+    Repo.delete(transaction)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking transaction changes.
+
+  ## Examples
+
+      iex> change_transaction(transaction)
+      %Ecto.Changeset{data: %Transaction{}}
+
+  """
+  def change_transaction(%Transaction{} = transaction, attrs \\ %{}) do
+    Transaction.changeset(transaction, attrs)
+  end
+
+  alias BankingApi.Bank.Posting
+
+  @doc """
+  Returns the list of postings.
+
+  ## Examples
+
+      iex> list_postings()
+      [%Posting{}, ...]
+
+  """
+  def list_postings do
+    Posting
+    |> Repo.all()
+    |> Repo.preload([:account, :transaction])
+  end
+
+  @doc """
+  Gets a single posting.
+
+  Raises `Ecto.NoResultsError` if the Posting does not exist.
+
+  ## Examples
+
+      iex> get_posting!(123)
+      %Posting{}
+
+      iex> get_posting!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_posting!(id) do
+    Posting
+    |> Repo.get!(id)
+    |> Repo.preload([:account, :transaction])
+  end
 end

--- a/lib/banking_api/bank/posting.ex
+++ b/lib/banking_api/bank/posting.ex
@@ -1,0 +1,30 @@
+defmodule BankingApi.Bank.Posting do
+  @moduledoc """
+  The Posting module represent a credit or a debit posting to an account.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias BankingApi.Bank.{Account, Transaction}
+
+  schema "postings" do
+    field :amount, :decimal
+    field :type, :string
+
+    belongs_to :transaction, Transaction
+    belongs_to :account, Account
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(posting, attrs) do
+    posting
+    |> cast(attrs, [:type, :amount, :account_id, :transaction_id])
+    |> validate_required([:type, :amount])
+    |> validate_inclusion(:type, ["credit", "debit"])
+    |> validate_number(:amount, greater_than_or_equal_to: 0)
+    |> assoc_constraint(:account)
+    |> assoc_constraint(:transaction)
+  end
+end

--- a/lib/banking_api/bank/transaction.ex
+++ b/lib/banking_api/bank/transaction.ex
@@ -1,0 +1,50 @@
+defmodule BankingApi.Bank.Transaction do
+  @moduledoc """
+  The Transaction module keeps track of all Postings
+  in a transaction.
+
+  Credits and debits must balance in order to the Transaction
+  be valid.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias BankingApi.Bank.Posting
+
+  schema "transactions" do
+    field :date, :date
+    field :name, :string
+
+    has_many :postings, Posting
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(transaction, attrs) do
+    transaction
+    |> cast(attrs, [:name, :date])
+    |> validate_required([:name, :date])
+    |> cast_assoc(:postings, required: true)
+    |> validate_postings_balance
+  end
+
+  defp validate_postings_balance(%Ecto.Changeset{valid?: true} = changeset) do
+    postings = Ecto.Changeset.get_field(changeset, :postings)
+    mapped_postings = Enum.group_by(postings, fn p -> p.type end)
+
+    credit_sum = sum_postings(mapped_postings["credit"])
+    debit_sum = sum_postings(mapped_postings["debit"])
+
+    if credit_sum == debit_sum do
+      changeset
+    else
+      add_error(changeset, :postings, "credits and debits must balance")
+    end
+  end
+
+  defp validate_postings_balance(changeset), do: changeset
+
+  defp sum_postings(postings) do
+    Enum.reduce(postings, Decimal.new(0), fn p, acc -> Decimal.add(p.amount, acc) end)
+  end
+end

--- a/lib/banking_api_web/api/v1/controllers/user_controller.ex
+++ b/lib/banking_api_web/api/v1/controllers/user_controller.ex
@@ -20,7 +20,7 @@ defmodule BankingApiWeb.Api.V1.UserController do
     initial_accounts = [
       %{name: "Drawing", type: "equity", contra: true},
       %{name: "Accounts payable", type: "liability"},
-      %{name: "Cash", type: "asset"},
+      %{name: "Checking", type: "asset"},
       %{name: "Initial Credit", type: "equity"},
       %{name: "Accounts receivable", type: "equity"}
     ]

--- a/priv/repo/migrations/20200826125942_create_transactions.exs
+++ b/priv/repo/migrations/20200826125942_create_transactions.exs
@@ -1,0 +1,12 @@
+defmodule BankingApi.Repo.Migrations.CreateTransactions do
+  use Ecto.Migration
+
+  def change do
+    create table(:transactions) do
+      add :name, :string, null: false
+      add :date, :date, null: false
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20200826130339_create_postings.exs
+++ b/priv/repo/migrations/20200826130339_create_postings.exs
@@ -1,0 +1,17 @@
+defmodule BankingApi.Repo.Migrations.CreatePostings do
+  use Ecto.Migration
+
+  def change do
+    create table(:postings) do
+      add :type, :string, null: false
+      add :amount, :decimal, null: false
+      add :account_id, references(:accounts, on_delete: :nothing)
+      add :transaction_id, references(:transactions, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:postings, [:account_id])
+    create index(:postings, [:transaction_id])
+  end
+end

--- a/test/banking_api/bank/posting_test.exs
+++ b/test/banking_api/bank/posting_test.exs
@@ -1,0 +1,42 @@
+defmodule BankingApi.Bank.PostingTest do
+  use BankingApi.DataCase, async: true
+  alias BankingApi.Bank.Posting
+
+  describe "Posting.changeset/2" do
+    @valid_credit_params %{amount: 100, type: "credit"}
+    @valid_debit_params %{amount: 100, type: "debit"}
+    @invalid_type %{amount: 10, type: "invalid"}
+    @invalid_amount %{amount: -1, type: "credit"}
+
+    test "amount must be greater than or equal to 0" do
+      changeset = Posting.changeset(%Posting{}, @invalid_amount)
+
+      assert "must be greater than or equal to 0" in errors_on(changeset).amount
+    end
+
+    test "types that aren't either 'credit' nor 'debit' are invalid" do
+      changeset = Posting.changeset(%Posting{}, @invalid_type)
+
+      assert "is invalid" in errors_on(changeset).type
+    end
+
+    test "'credit' type is valid" do
+      changeset = Posting.changeset(%Posting{}, @valid_credit_params)
+
+      assert changeset.valid?
+    end
+
+    test "'debit' type is valid" do
+      changeset = Posting.changeset(%Posting{}, @valid_debit_params)
+
+      assert changeset.valid?
+    end
+
+    test "type and amount are required" do
+      changeset = Posting.changeset(%Posting{}, %{})
+
+      assert "can't be blank" in errors_on(changeset).type
+      assert "can't be blank" in errors_on(changeset).amount
+    end
+  end
+end

--- a/test/banking_api/bank/transaction_test.exs
+++ b/test/banking_api/bank/transaction_test.exs
@@ -1,0 +1,81 @@
+defmodule BankingApi.Bank.TransactionTest do
+  use BankingApi.DataCase, async: true
+  alias BankingApi.Bank.Transaction
+
+  describe "Transaction.changeset/2" do
+    @without_postings %{name: "Name", date: ~D[2000-03-10]}
+    @invalid_attrs %{name: nil, date: nil}
+
+    test "isn't valid without postings" do
+      changeset = Transaction.changeset(%Transaction{}, @without_postings)
+
+      assert "can't be blank" in errors_on(changeset).postings
+    end
+
+    test "isn't valid without name and date" do
+      changeset = Transaction.changeset(%Transaction{}, @invalid_attrs)
+
+      assert "can't be blank" in errors_on(changeset).name
+      assert "can't be blank" in errors_on(changeset).date
+    end
+
+    test "is valid when credits and debits postings balance" do
+      credit_account = insert(:account, name: "Restaurant", type: "liability")
+      debit_account = insert(:account, name: "Checking", type: "asset")
+      date = Date.utc_today()
+
+      params = %{
+        name: "Dinner",
+        date: date,
+        postings: [
+          %{type: "debit", amount: 1000, account_id: credit_account.id},
+          %{type: "credit", amount: 1000, account_id: debit_account.id}
+        ]
+      }
+
+      changeset = Transaction.changeset(%Transaction{}, params)
+
+      assert changeset.valid?
+    end
+
+    test "is valid with many postings when credits and debits balance" do
+      credit_account = insert(:account, name: "Restaurant", type: "liability")
+      debit_account = insert(:account, name: "Checking", type: "asset")
+      date = Date.utc_today()
+
+      params = %{
+        name: "Dinner",
+        date: date,
+        postings: [
+          %{type: "debit", amount: 500, account_id: credit_account.id},
+          %{type: "debit", amount: 500, account_id: credit_account.id},
+          %{type: "credit", amount: 600, account_id: debit_account.id},
+          %{type: "credit", amount: 400, account_id: debit_account.id}
+        ]
+      }
+
+      changeset = Transaction.changeset(%Transaction{}, params)
+
+      assert changeset.valid?
+    end
+
+    test "isn't valid when credits and debits doesn't balance" do
+      credit_account = insert(:account, name: "Restaurant", type: "liability")
+      debit_account = insert(:account, name: "Checking", type: "asset")
+      date = Date.utc_today()
+
+      params = %{
+        name: "Dinner",
+        date: date,
+        postings: [
+          %{type: "debit", amount: 1000, account_id: credit_account.id},
+          %{type: "credit", amount: 1100, account_id: debit_account.id}
+        ]
+      }
+
+      changeset = Transaction.changeset(%Transaction{}, params)
+
+      assert "credits and debits must balance" in errors_on(changeset).postings
+    end
+  end
+end

--- a/test/banking_api/bank_test.exs
+++ b/test/banking_api/bank_test.exs
@@ -88,4 +88,65 @@ defmodule BankingApi.BankTest do
       assert %Ecto.Changeset{} = Bank.change_account(account)
     end
   end
+
+  describe "transactions" do
+    alias BankingApi.Bank.{Posting, Transaction}
+
+    test "list_transactions/0 returns all transactions" do
+      transaction = insert(:transaction)
+
+      assert Bank.list_transactions() == [transaction]
+    end
+
+    test "get_transaction!/1 returns the transaction with given id" do
+      transaction = insert(:transaction)
+
+      assert Bank.get_transaction!(transaction.id) == transaction
+    end
+
+    test "create_transaction/1 creates associated posts" do
+      credit_account = insert(:account, name: "Restaurant", type: "liability")
+      debit_account = insert(:account, name: "Checking", type: "asset")
+      date = Date.utc_today()
+
+      params = %{
+        name: "Dinner",
+        date: date,
+        postings: [
+          %{type: "debit", amount: 1000, account_id: credit_account.id},
+          %{type: "credit", amount: 1000, account_id: debit_account.id}
+        ]
+      }
+
+      assert {:ok, %Transaction{} = transaction} = Bank.create_transaction(params)
+      assert transaction.date == date
+      assert transaction.name == "Dinner"
+
+      assert [
+               %Posting{type: "debit"} = debit_posting,
+               %Posting{type: "credit"} = credit_posting
+             ] = transaction.postings
+
+      assert debit_posting.amount == Decimal.new(1000)
+      assert credit_posting.amount == Decimal.new(1000)
+      assert debit_posting.account == credit_account
+      assert credit_posting.account == debit_account
+    end
+  end
+
+  describe "postings" do
+    alias BankingApi.Bank.Posting
+
+    test "list_postings/0 returns all postings" do
+      posting = insert(:credit)
+
+      assert Bank.list_postings() == [posting]
+    end
+
+    test "get_posting!/1 returns the posting with given id" do
+      posting = insert(:debit)
+
+      assert Bank.get_posting!(posting.id) == posting
+    end
+  end
 end

--- a/test/banking_api/bank_test.exs
+++ b/test/banking_api/bank_test.exs
@@ -6,10 +6,10 @@ defmodule BankingApi.BankTest do
   describe "accounts" do
     alias BankingApi.Bank.Account
 
-    @valid_attrs %{contra: false, name: "Cash", type: "asset", user_id: 1}
+    @valid_attrs %{contra: false, name: "Checking", type: "asset", user_id: 1}
     @update_attrs %{contra: true, name: "Drawing", type: "asset"}
     @invalid_attrs %{contra: nil, name: nil, type: nil}
-    @invalid_type_attrs %{contra: false, name: "Cash", type: "invalid"}
+    @invalid_type_attrs %{contra: false, name: "Checking", type: "invalid"}
 
     setup %{} do
       user = insert(:user)
@@ -30,7 +30,7 @@ defmodule BankingApi.BankTest do
     test "create_account/1 with valid data creates a account", %{valid_attrs: valid_attrs} do
       assert {:ok, %Account{} = account} = Bank.create_account(valid_attrs)
       assert account.contra == false
-      assert account.name == "Cash"
+      assert account.name == "Checking"
       assert account.type == "asset"
     end
 

--- a/test/banking_api_web/api/v1/controllers/user_controller_test.exs
+++ b/test/banking_api_web/api/v1/controllers/user_controller_test.exs
@@ -37,7 +37,7 @@ defmodule BankingApiWeb.Api.V1.UserControllerTest do
       assert [
                %{name: "Accounts receivable", type: "equity"},
                %{name: "Initial Credit", type: "equity"},
-               %{name: "Cash", type: "asset"},
+               %{name: "Checking", type: "asset"},
                %{name: "Accounts payable", type: "liability"},
                %{name: "Drawing", type: "equity", contra: true}
              ] = user.accounts

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,7 +4,7 @@ defmodule BankingApi.Factory do
   use ExMachina.Ecto, repo: BankingApi.Repo
 
   alias BankingApi.Accounts.User
-  alias BankingApi.Bank.Account
+  alias BankingApi.Bank.{Transaction, Posting, Account}
 
   def user_factory do
     email = sequence(:email, &"user#{&1}@email.com")
@@ -19,9 +19,40 @@ defmodule BankingApi.Factory do
     user = insert(:user)
 
     %Account{
-      name: "Cash",
+      name: "Checking",
       type: "asset",
       user_id: user.id
+    }
+  end
+
+  def transaction_factory do
+    %Transaction{
+      name: "Checking",
+      date: ~D[2000-03-10]
+    }
+  end
+
+  def debit_factory do
+    account = insert(:account)
+    transaction = insert(:transaction)
+
+    %Posting{
+      amount: 1000,
+      type: "debit",
+      account: account,
+      transaction: transaction
+    }
+  end
+
+  def credit_factory do
+    account = insert(:account)
+    transaction = insert(:transaction)
+
+    %Posting{
+      amount: 1000,
+      type: "credit",
+      account: account,
+      transaction: transaction
     }
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,7 +4,7 @@ defmodule BankingApi.Factory do
   use ExMachina.Ecto, repo: BankingApi.Repo
 
   alias BankingApi.Accounts.User
-  alias BankingApi.Bank.{Transaction, Posting, Account}
+  alias BankingApi.Bank.{Account, Posting, Transaction}
 
   def user_factory do
     email = sequence(:email, &"user#{&1}@email.com")


### PR DESCRIPTION
Creates `Transaction` and `Posting` modules to handle transactions between accounts.

In order to a `Transaction` be valid, its `credits` and `debits` postings must be **equal**.

It's possible to create any number of postings, as long as they balance.