### PR TITLE
Add buildpack config

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,0 +1,2 @@
+elixir_version=1.10.2
+erlang_version=22


### PR DESCRIPTION
Set elixir & erlang versions for gigalixir in order to fix the following error:

```
-----> Copying hex from /app/.mix/archives/hex-0.20.5
-----> Compiling
remote: ** (Mix) You're trying to run :banking_api on Elixir v1.5.3 but it has declared in its mix.exs file it supports only Elixir ~> 1.10.2
remote: Deploy aborted
```