### PR TITLE
Fix cache error

### DIFF
--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,1 +1,5 @@
 node_version=12.16.3
+phoenix_relative_path=.
+phoenix_ex=phx
+assets_path=assets
+clean_cache=true


### PR DESCRIPTION
According to [this issue](https://github.com/gjaldon/heroku-buildpack-phoenix-static/issues/80), there's no other workaround for now