### PR TITLE
Remove name field from transactions

### DIFF
--- a/lib/banking_api/bank.ex
+++ b/lib/banking_api/bank.ex
@@ -218,7 +218,6 @@ defmodule BankingApi.Bank do
         initial_credit_cents = amount_to_cents(1000)
 
         create_transaction(%{
-          name: "Initial Credit",
           date: Date.utc_today(),
           amount_cents: initial_credit_cents,
           to_user_id: user.id,
@@ -280,7 +279,6 @@ defmodule BankingApi.Bank do
           })
 
         create_transaction(%{
-          name: "Withdraw",
           date: Date.utc_today(),
           amount_cents: amount_cents,
           from_user_id: user.id,
@@ -324,7 +322,6 @@ defmodule BankingApi.Bank do
           })
 
         create_transaction(%{
-          name: "Transfer",
           date: Date.utc_today(),
           amount_cents: amount_cents,
           from_user_id: user.id,

--- a/lib/banking_api/bank/transaction.ex
+++ b/lib/banking_api/bank/transaction.ex
@@ -14,7 +14,7 @@ defmodule BankingApi.Bank.Transaction do
   alias BankingApi.Bank
   alias BankingApi.Bank.Posting
 
-  @fields [:name, :date, :amount_cents, :type, :from_user_id, :to_user_id]
+  @fields [:date, :amount_cents, :type, :from_user_id, :to_user_id]
 
   @transfer "transfer"
   @deposit "deposit"
@@ -23,7 +23,6 @@ defmodule BankingApi.Bank.Transaction do
 
   schema "transactions" do
     field :date, :date
-    field :name, :string
     field :type, :string
     field :amount_cents, :decimal
 
@@ -38,7 +37,7 @@ defmodule BankingApi.Bank.Transaction do
   def changeset(transaction, attrs) do
     transaction
     |> cast(attrs, @fields)
-    |> validate_required([:name, :date, :amount_cents, :type])
+    |> validate_required([:date, :amount_cents, :type])
     |> validate_number(:amount_cents, greater_than: 0)
     |> validate_inclusion(:type, @valid_types)
     |> assoc_constraint(:from_user)

--- a/lib/banking_api_web/templates/back_office/index.html.eex
+++ b/lib/banking_api_web/templates/back_office/index.html.eex
@@ -2,7 +2,7 @@
 <h3>Your balance is R$ <%= amount_from_cents(@user.balance) %></h3>
 <table style="width:100%">
   <tr>
-    <th>Name</th>
+    <th>Id</th>
     <th>Amount</th>
     <th>Type</th>
     <th>From</th>
@@ -11,7 +11,7 @@
   </tr>
   <%= for transaction <- @transactions do %>
     <tr>
-      <td><%= transaction.name %></td>
+      <td><%= transaction.id %></td>
       <td>R$ <%= amount_from_cents(transaction.amount_cents) %></td>
       <td><%= transaction.type %></td>
       <td><%= transaction_target(transaction.from_user) %></td>

--- a/priv/repo/migrations/20200911144323_remove_name_from_transactions.exs
+++ b/priv/repo/migrations/20200911144323_remove_name_from_transactions.exs
@@ -1,0 +1,9 @@
+defmodule BankingApi.Repo.Migrations.RemoveNameFromTransactions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:transactions) do
+      remove :name
+    end
+  end
+end

--- a/test/banking_api/bank/transaction_test.exs
+++ b/test/banking_api/bank/transaction_test.exs
@@ -3,8 +3,8 @@ defmodule BankingApi.Bank.TransactionTest do
   alias BankingApi.Bank.Transaction
 
   describe "Transaction.changeset/2" do
-    @without_postings %{name: "Name", date: ~D[2000-03-10]}
-    @invalid_attrs %{name: nil, date: nil}
+    @without_postings %{date: ~D[2000-03-10]}
+    @invalid_attrs %{date: nil}
 
     test "isn't valid without postings" do
       changeset = Transaction.changeset(%Transaction{}, @without_postings)
@@ -12,10 +12,10 @@ defmodule BankingApi.Bank.TransactionTest do
       assert "can't be blank" in errors_on(changeset).postings
     end
 
-    test "isn't valid without name and date" do
+    test "isn't valid without type and date" do
       changeset = Transaction.changeset(%Transaction{}, @invalid_attrs)
 
-      assert "can't be blank" in errors_on(changeset).name
+      assert "can't be blank" in errors_on(changeset).type
       assert "can't be blank" in errors_on(changeset).date
     end
 
@@ -27,7 +27,6 @@ defmodule BankingApi.Bank.TransactionTest do
       date = Date.utc_today()
 
       params = %{
-        name: "Dinner",
         date: date,
         amount_cents: 1000,
         type: "transfer",
@@ -48,7 +47,6 @@ defmodule BankingApi.Bank.TransactionTest do
       date = Date.utc_today()
 
       params = %{
-        name: "Dinner",
         date: date,
         amount_cents: 1000,
         type: "transfer",
@@ -73,7 +71,6 @@ defmodule BankingApi.Bank.TransactionTest do
       date = Date.utc_today()
 
       params = %{
-        name: "Dinner",
         date: date,
         type: "transfer",
         amount_cents: 1000,
@@ -94,7 +91,6 @@ defmodule BankingApi.Bank.TransactionTest do
     @withdraw "withdraw"
     @valid_withdraw_attrs %{
       type: @withdraw,
-      name: @withdraw,
       date: ~D[2000-03-10],
       amount_cents: 50_000,
       from_user_id: 1,

--- a/test/banking_api/bank_test.exs
+++ b/test/banking_api/bank_test.exs
@@ -64,7 +64,6 @@ defmodule BankingApi.BankTest do
       date = Date.utc_today()
 
       params = %{
-        name: "Dinner",
         date: date,
         from_user_id: user.id,
         type: "transfer",
@@ -77,7 +76,6 @@ defmodule BankingApi.BankTest do
 
       assert {:ok, %Transaction{} = transaction} = Bank.create_transaction(params)
       assert transaction.date == date
-      assert transaction.name == "Dinner"
 
       assert [
                %Posting{type: "debit"} = debit_posting,

--- a/test/integration/back_office_test.exs
+++ b/test/integration/back_office_test.exs
@@ -49,7 +49,7 @@ defmodule BankingApi.BackOfficeTest do
     defp transaction_on_the_table?(transaction, table) do
       table
       |> visible_text
-      |> String.contains?(transaction.name)
+      |> String.contains?(to_string(transaction.id))
     end
 
     defp transaction_table_items do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -46,7 +46,6 @@ defmodule BankingApi.Factory do
 
   def transaction_factory do
     %Transaction{
-      name: "Dinner",
       date: ~D[2000-03-10],
       amount_cents: 1000,
       type: "withdraw"
@@ -61,7 +60,6 @@ defmodule BankingApi.Factory do
       Map.get(attrs, :credit_account, insert(:credit_account, user: user, type: "equity"))
 
     %Transaction{
-      name: "Deposit",
       date: Date.utc_today(),
       amount_cents: 100_000,
       to_user_id: user.id,


### PR DESCRIPTION
There's no need for this field, since we map different transactions by `type` and users can't specify a name.